### PR TITLE
Add process.env.NODE_ENV handling for Rollup and Rolldown

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "npm run be && npm run bp && npm run brd && npm run bru && npm run brp && npm run bv && npm run bw"
   },
   "dependencies": {
+    "@rollup/plugin-replace": "^6.0.2",
     "chart.js": "^4.4.7",
     "ckeditor5": "^44.0.0",
     "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "build": "npm run be && npm run bp && npm run brd && npm run bru && npm run brp && npm run bv && npm run bw"
   },
   "dependencies": {
-    "@rollup/plugin-replace": "^6.0.2",
     "chart.js": "^4.4.7",
     "ckeditor5": "^44.0.0",
     "d3": "^7.9.0",
@@ -26,6 +25,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",
+    "@rollup/plugin-replace": "^6.0.2",
     "@rspack/cli": "^1.1.3",
     "@types/webpack": "^5.28.5",
     "esbuild": "^0.24.0",

--- a/rolldown.config.mjs
+++ b/rolldown.config.mjs
@@ -10,6 +10,9 @@ export default defineConfig( {
 		minify: false,
 		comments: 'none'
 	},
+	define: {
+		'process.env.NODE_ENV': '"production"',
+	},
 	plugins: [
 		minify( {
 			minify: true,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'rollup';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import esbuild from 'rollup-plugin-esbuild';
+import replace from '@rollup/plugin-replace';
 
 export default defineConfig( {
 	input: 'src/index.js',
@@ -10,6 +11,11 @@ export default defineConfig( {
 		format: 'es'
 	},
 	plugins: [
+		replace( {
+			values: {
+				'process.env.NODE_ENV': '"production"',
+			}
+		} ),
 		commonjs( {
 			sourceMap: true,
 			defaultIsModuleExports: true


### PR DESCRIPTION
I noticed from the updated [blog post](https://dev.to/filipsobol/downsize-your-javascript-mastering-bundler-optimizations-2485) that Rollup and Rolldown shows unreasonably large bundles in the individual library cases for MobX.

Turns out MobX uses the `process.env.NODE_ENV` env variable as a compile-time flag to branch some dev-only code, in this case tons of error messages. This is also common practice that exists in many libraries, including React and Vue.

- Vite, esbuild, parcel, and rspack / webpack all shim this implicitly (in production mode, or when minify is enabled).
- Rollup doesn't have the concept of production / minify, so it must be explicitly enabled via its replace plugin.
- For Rolldown, we will shim this when the target is `browser` (default) and `minify` option is true. However in this case because we are still using a separate minifier, we also need to explicitly enable it via the `define` option.