### PR TITLE
fix: ignore context require for `moment/locale` for webpack

### DIFF
--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -1,15 +1,17 @@
 import { defineConfig } from '@rspack/cli';
+import { IgnoreMomentLocale } from './webpack-plugin-ignore-moment-locales.mjs'; 
 
 // The commented out options are valid, but for some reason increase the bundle size by a lot.
 
 export default defineConfig({
-	entry: './src/index.js',
-	devtool: false,
-	// target: 'es2022',
-	output: {
-		// chunkFormat: 'module',
-		// chunkLoading: 'import',
-		filename: 'rspack.js',
-		clean: false
-	}
-} );
+  entry: './src/index.js',
+  devtool: false,
+  // target: 'es2022',
+  output: {
+    // chunkFormat: 'module',
+    // chunkLoading: 'import',
+    filename: 'rspack.js',
+    clean: false,
+  },
+  plugins: [new IgnoreMomentLocale()],
+});

--- a/webpack-plugin-ignore-moment-locales.mjs
+++ b/webpack-plugin-ignore-moment-locales.mjs
@@ -1,0 +1,15 @@
+const PLUGIN_NAME = "ignore-moment-locales-plugin"
+
+export class IgnoreMomentLocale {
+  /**@type {import('webpack').Compiler} */
+  apply(compiler) {
+    compiler.hooks.contextModuleFactory.tap(PLUGIN_NAME, (cmf) => {
+      cmf.hooks.beforeResolve.tap(PLUGIN_NAME, (data) => {
+        if (data.request === './locale' && data.context.includes('node_modules/moment')) {
+          return false
+        }
+      })
+    })
+  }
+}
+

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -1,4 +1,5 @@
 import Terser from 'terser-webpack-plugin';
+import { IgnoreMomentLocale } from './webpack-plugin-ignore-moment-locales.mjs'; 
 
 export default {
   entry: './src/index.js',

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -6,6 +6,9 @@ export default {
     filename: 'webpack.js',
     clean: false
   },
+  plugins: [
+    new IgnoreMomentLocale()
+  ],
   optimization: {
     minimize: true,
     minimizer: [


### PR DESCRIPTION
There is a lib `moment` which contains code like

```
var aliasRequire = require
aliasRequire('./locale' + name)
```

This means require subfoloder in `moment` dynamically.

Rollup, webpack and Rspack all contains these statements, only webpack/Rspack bundles the sub modules which is correct and more safe. But I think it's better to ignore these to make it more fair