### PR TITLE
chore: enable process.env.NODE_ENV handling for webpack

### DIFF
--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -1,22 +1,33 @@
+import { DefinePlugin } from 'webpack';
 import Terser from 'terser-webpack-plugin';
+import { plugins } from 'chart.js';
 
 export default {
   entry: './src/index.js',
+  mode: 'production',
   output: {
     filename: 'webpack.js',
     clean: false
   },
+  plugins: [
+    new DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      'import.meta.env.DEV': (false).toString(),
+      'import.meta.env.PROD': (true).toString(),
+      'typeof window': JSON.stringify('object'),
+    })
+  ],
   optimization: {
     minimize: true,
     minimizer: [
-      new Terser( {
+      new Terser({
         minify: Terser.swcMinify,
         terserOptions: {
           format: {
             comments: false
           }
         }
-      } )
+      })
     ]
   }
 };


### PR DESCRIPTION
It is not fair to only enable `process.env.NODE_ENV` handling in rollup w/o enabling it in webpack.